### PR TITLE
Fix babel trouble

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdPanel from './index.es6';
+import AdPanel from './index';
 // ((run) => {
 //   if (!run) {
 //     return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-ad-panel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An advert panel using GPT tags",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-ad-panel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An advert panel using GPT tags",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
We get failed builds when we require `./filename.es6` instead of `./filename`. Working around that.